### PR TITLE
Fix sudachipy version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [Version 1.2.2](https://github.com/dataiku/dss-plugin-nlp-preparation/releases/tag/v1.2.2)
+- Fix sudachipy version not being compatible with Python 3.6 anymore
+
 ## [Version 1.2.1](https://github.com/dataiku/dss-plugin-nlp-preparation/releases/tag/v1.2.1) - Bugfix release - 2021-06
 - ✨ Improved Japanese stopwords
 - 🐛 Add explicit UI for languages which do not support lemmatization

--- a/code-env/python/spec/requirements.txt
+++ b/code-env/python/spec/requirements.txt
@@ -11,3 +11,4 @@ regex==2021.4.4
 spacy[lookups,ja,th]==2.3.5
 symspellpy==6.7.0
 tqdm==4.60.0
+sudachipy==0.6.0; python_version == '3.6'

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
     "id": "nlp-preparation",
-    "version": "1.2.1",
+    "version": "1.2.2",
     "meta": {
         "label": "Text Preparation",
         "category": "Natural Language Processing",


### PR DESCRIPTION
Same problem with [several other plugins](https://github.com/dataiku/dss-plugin-nlp-visualization/blob/main/code-env/python/spec/requirements.txt).
Will open a PR there once this is merged.

There is no wheel available anymore for Py3 & sudachi py >0.6, hence requiring Rust to install. We remove this requirement by pinning a version.