### PR TITLE
Pin sudachipy for python 3.7 and 3.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [Version 1.3.1](https://github.com/dataiku/dss-plugin-nlp-preparation/releases/tag/v1.3.1) - Bugfix release - 2025-01
+- 🐛 Fixed code env building on Python 3.7 and 3.8
+
 ## [Version 1.3.0](https://github.com/dataiku/dss-plugin-nlp-preparation/releases/tag/v1.3.0) - New feature - 2023-04
 - ✨ Added Python 3.8 and 3.9 support
 

--- a/code-env/python/spec/requirements.txt
+++ b/code-env/python/spec/requirements.txt
@@ -12,4 +12,5 @@ spacy[lookups,ja,th]==2.3.5
 symspellpy==6.7.0
 tqdm==4.60.0
 sudachipy==0.6.0; python_version == '3.6'
-sudachipy<0.6.10; python_version >= '3.7' and python_version < '3.9'
+sudachipy<0.6.10; python_version >= '3.7' and python_version < '3.9' and platform_system != "Darwin"
+sudachipy<0.6.9; python_version >= '3.7' and python_version < '3.9' and platform_system == "Darwin"'

--- a/code-env/python/spec/requirements.txt
+++ b/code-env/python/spec/requirements.txt
@@ -13,4 +13,4 @@ symspellpy==6.7.0
 tqdm==4.60.0
 sudachipy==0.6.0; python_version == '3.6'
 sudachipy<0.6.10; python_version >= '3.7' and python_version < '3.9' and platform_system != "Darwin"
-sudachipy<0.6.9; python_version >= '3.7' and python_version < '3.9' and platform_system == "Darwin"'
+sudachipy<0.6.9; python_version >= '3.7' and python_version < '3.9' and platform_system == "Darwin"

--- a/code-env/python/spec/requirements.txt
+++ b/code-env/python/spec/requirements.txt
@@ -12,3 +12,4 @@ spacy[lookups,ja,th]==2.3.5
 symspellpy==6.7.0
 tqdm==4.60.0
 sudachipy==0.6.0; python_version == '3.6'
+sudachipy<0.6.10; python_version >= '3.7' and python_version < '3.9'

--- a/plugin.json
+++ b/plugin.json
@@ -1,11 +1,11 @@
 {
     "id": "nlp-preparation",
-    "version": "1.3.0",
+    "version": "1.3.1",
     "meta": {
         "label": "Text Preparation",
         "category": "Natural Language Processing",
         "description": "Prepare text data with language detection, spell checking and text cleaning",
-        "author": "Dataiku (Alex COMBESSIE, Damien JACQUEMART)",
+        "author": "Dataiku (CaraML)",
         "icon": "icon-align-justify",
         "tags": [
             "NLP"


### PR DESCRIPTION
Sudachipy released on the 10th of january 2025 version 0.6.10, with no wheels for python3.8 and before : 

https://pypi.org/project/SudachiPy/0.6.10/#files